### PR TITLE
Bugfixes v2.3.13

### DIFF
--- a/src/AntiDupl.NET.WinForms/GUIControl/MainMenu.cs
+++ b/src/AntiDupl.NET.WinForms/GUIControl/MainMenu.cs
@@ -219,9 +219,9 @@ namespace AntiDupl.NET.WinForms
             m_view_hotKeysMenuItem.Text = s.MainMenu_View_HotKeysMenuItem_Text;
             m_view_stretchSmallImageMenuItem.Text = s.MainMenu_View_StretchSmallImagesMenuItem_Text;
             m_view_proportionalImageViewMenuItem.Text = s.MainMenu_View_ProportionalImageSizeMenuItem_Text;
-            if (m_options.hotKeyOptions.keys.Length > (int)HotKeyOptions.Action.ShowNeighbours &&
-                m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.ShowNeighbours] != null)
-                    m_view_showNeighbourImageMenuItem.Text = s.MainMenu_View_ShowNeighbourImageMenuItem_Text + String.Format(" ({0})", m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.ShowNeighbours].ToString().Replace(',', '+'));
+            Keys showNeighboursHotKey = m_options.hotKeyOptions.Get(HotKeyOptions.Action.ShowNeighbours);
+            if (showNeighboursHotKey != Keys.None)
+                m_view_showNeighbourImageMenuItem.Text = s.MainMenu_View_ShowNeighbourImageMenuItem_Text + String.Format(" ({0})", showNeighboursHotKey.ToString().Replace(',', '+'));
             else
                 m_view_showNeighbourImageMenuItem.Text = s.MainMenu_View_ShowNeighbourImageMenuItem_Text;
 

--- a/src/AntiDupl.NET.WinForms/GUIControl/ResultsListView.cs
+++ b/src/AntiDupl.NET.WinForms/GUIControl/ResultsListView.cs
@@ -319,6 +319,10 @@ namespace AntiDupl.NET.WinForms
         /// <param name="hotKey"></param>
         private void MakeAction(Keys hotKey)
         {
+            KeyEventArgs keyEventArgs = new KeyEventArgs(hotKey);
+            if (keyEventArgs.KeyCode == Keys.ShiftKey || keyEventArgs.KeyCode == Keys.ControlKey || keyEventArgs.KeyCode == Keys.Menu)
+                return;
+
             if (hotKey == (Keys.Z | Keys.Control) && m_core.CanApply(CoreDll.ActionEnableType.Undo))
             {
                 ProgressForm progressForm = new ProgressForm(ProgressForm.Type.Undo, m_core, m_options, m_coreOptions, m_mainSplitContainer);
@@ -337,29 +341,29 @@ namespace AntiDupl.NET.WinForms
             {
                 if (m_results[m_currentRowIndex].type == CoreDll.ResultType.DefectImage)
                 {
-                    if (hotKey == m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.CurrentDefectDelete])
+                    if (hotKey == m_options.hotKeyOptions.Get(HotKeyOptions.Action.CurrentDefectDelete))
                         MakeAction(CoreDll.LocalActionType.DeleteDefect, CoreDll.TargetType.Current);
-                    else if (hotKey == m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.CurrentMistake])
+                    else if (hotKey == m_options.hotKeyOptions.Get(HotKeyOptions.Action.CurrentMistake))
                         MakeAction(CoreDll.LocalActionType.Mistake, CoreDll.TargetType.Current);
                     return;
                 }
                 if (m_results[m_currentRowIndex].type == CoreDll.ResultType.DuplImagePair)
                 {
-                    if (hotKey == m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.CurrentDuplPairDeleteFirst])
+                    if (hotKey == m_options.hotKeyOptions.Get(HotKeyOptions.Action.CurrentDuplPairDeleteFirst))
                         MakeAction(CoreDll.LocalActionType.DeleteFirst, CoreDll.TargetType.Current);
-                    else if (hotKey == m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.CurrentDuplPairDeleteSecond])
+                    else if (hotKey == m_options.hotKeyOptions.Get(HotKeyOptions.Action.CurrentDuplPairDeleteSecond))
                         MakeAction(CoreDll.LocalActionType.DeleteSecond, CoreDll.TargetType.Current);
-                    else if (hotKey == m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.CurrentDuplPairDeleteBoth])
+                    else if (hotKey == m_options.hotKeyOptions.Get(HotKeyOptions.Action.CurrentDuplPairDeleteBoth))
                         MakeAction(CoreDll.LocalActionType.DeleteBoth, CoreDll.TargetType.Current);
-                    else if (hotKey == m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.CurrentDuplPairRenameFirstToSecond])
+                    else if (hotKey == m_options.hotKeyOptions.Get(HotKeyOptions.Action.CurrentDuplPairRenameFirstToSecond))
                         MakeAction(CoreDll.LocalActionType.RenameFirstToSecond, CoreDll.TargetType.Current);
-                    else if (hotKey == m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.CurrentDuplPairRenameSecondToFirst])
+                    else if (hotKey == m_options.hotKeyOptions.Get(HotKeyOptions.Action.CurrentDuplPairRenameSecondToFirst))
                         MakeAction(CoreDll.LocalActionType.RenameSecondToFirst, CoreDll.TargetType.Current);
-                    else if (hotKey == m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.CurrentMistake])
+                    else if (hotKey == m_options.hotKeyOptions.Get(HotKeyOptions.Action.CurrentMistake))
                         MakeAction(CoreDll.LocalActionType.Mistake, CoreDll.TargetType.Current);
-                    else if (hotKey == m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.ShowNeighbours])
+                    else if (hotKey == m_options.hotKeyOptions.Get(HotKeyOptions.Action.ShowNeighbours))
                         m_options.resultsOptions.ShowNeighboursImages = !m_options.resultsOptions.ShowNeighboursImages;
-                    else if (hotKey == m_options.hotKeyOptions.keys[(int)HotKeyOptions.Action.OpenImageDiff])
+                    else if (hotKey == m_options.hotKeyOptions.Get(HotKeyOptions.Action.OpenImageDiff))
                     {
                         var result = m_results[m_currentRowIndex];
                         ImageDiffOpener.OpenFiles(result.first.path, result.second.path, m_options.imageDiffExecutablePath, m_options.imageDiffExecutableArguments);

--- a/src/AntiDupl.NET.WinForms/GUIControl/ResultsPreviewBase.cs
+++ b/src/AntiDupl.NET.WinForms/GUIControl/ResultsPreviewBase.cs
@@ -150,7 +150,7 @@ namespace AntiDupl.NET.WinForms
 
         protected string GetToolTip(string toolTip, HotKeyOptions.Action action)
         {
-            return GetToolTip(toolTip, m_options.hotKeyOptions.keys[(int)action]);
+            return GetToolTip(toolTip, m_options.hotKeyOptions.Get(action));
         }
 
         

--- a/src/AntiDupl.NET.WinForms/HotKeyOptions.cs
+++ b/src/AntiDupl.NET.WinForms/HotKeyOptions.cs
@@ -55,13 +55,35 @@ namespace AntiDupl.NET.WinForms
         public HotKeyOptions(HotKeyOptions options)
         {
             keys = new Keys[(int)Action.Size];
-            if (options.keys.Length == (int)Action.Size)
+            SetDefault();
+            if (options != null && options.keys != null)
             {
-                for (int i = 0; i < keys.Length; ++i)
+                for (int i = 0; i < Math.Min(options.keys.Length, keys.Length); ++i)
                     keys[i] = options.keys[i];
             }
-            else
-                SetDefault();
+        }
+
+        public void Check()
+        {
+            int size = (int)Action.Size;
+            if (keys != null && keys.Length == size)
+                return;
+
+            Keys[] previous = keys;
+            keys = new Keys[size];
+            SetDefault();
+
+            if (previous != null)
+            {
+                for (int i = 0; i < Math.Min(previous.Length, size); ++i)
+                    keys[i] = previous[i];
+            }
+        }
+
+        public Keys Get(Action action)
+        {
+            Check();
+            return keys[(int)action];
         }
         
         public void SetDefault()

--- a/src/AntiDupl.NET.WinForms/HotKeyOptions.cs
+++ b/src/AntiDupl.NET.WinForms/HotKeyOptions.cs
@@ -48,19 +48,14 @@ namespace AntiDupl.NET.WinForms
         
         public HotKeyOptions()
         {
-            keys = new Keys[(int)Action.Size];
-            SetDefault();
+            keys = null;
+            Check();
         }
     
         public HotKeyOptions(HotKeyOptions options)
         {
-            keys = new Keys[(int)Action.Size];
-            SetDefault();
-            if (options != null && options.keys != null)
-            {
-                for (int i = 0; i < Math.Min(options.keys.Length, keys.Length); ++i)
-                    keys[i] = options.keys[i];
-            }
+            keys = options != null && options.keys != null ? (Keys[])options.keys.Clone() : null;
+            Check();
         }
 
         public void Check()
@@ -71,13 +66,42 @@ namespace AntiDupl.NET.WinForms
 
             Keys[] previous = keys;
             keys = new Keys[size];
-            SetDefault();
 
             if (previous != null)
             {
                 for (int i = 0; i < Math.Min(previous.Length, size); ++i)
                     keys[i] = previous[i];
             }
+
+            EnsureDefaultIfEmpty(Action.CurrentDefectDelete, Keys.NumPad1);
+            EnsureDefaultIfEmpty(Action.CurrentDuplPairDeleteFirst, Keys.NumPad1);
+            EnsureDefaultIfEmpty(Action.CurrentDuplPairDeleteSecond, Keys.NumPad2);
+            EnsureDefaultIfEmpty(Action.CurrentDuplPairDeleteBoth, Keys.NumPad3);
+            EnsureDefaultIfEmpty(Action.CurrentDuplPairRenameFirstToSecond, Keys.NumPad4);
+            EnsureDefaultIfEmpty(Action.CurrentDuplPairRenameSecondToFirst, Keys.NumPad6);
+            EnsureDefaultIfEmpty(Action.CurrentMistake, Keys.NumPad5);
+            EnsureDefaultIfEmpty(Action.ShowNeighbours, Keys.Control | Keys.Q);
+            EnsureDefaultIfEmpty(Action.OpenImageDiff, Keys.Control | Keys.D);
+        }
+
+        private void EnsureDefaultIfEmpty(Action action, Keys defaultKey)
+        {
+            int index = (int)action;
+            if (keys[index] == Keys.None && !IsKeyUsed(defaultKey, action))
+                keys[index] = defaultKey;
+        }
+
+        private bool IsKeyUsed(Keys key, Action exceptAction)
+        {
+            if (key == Keys.None)
+                return false;
+
+            for (int i = 0; i < keys.Length; ++i)
+            {
+                if (i != (int)exceptAction && keys[i] == key)
+                    return true;
+            }
+            return false;
         }
 
         public Keys Get(Action action)
@@ -88,6 +112,7 @@ namespace AntiDupl.NET.WinForms
         
         public void SetDefault()
         {
+            keys = new Keys[(int)Action.Size];
             keys[(int)Action.CurrentDefectDelete] = Keys.NumPad1;
             keys[(int)Action.CurrentDuplPairDeleteFirst] = Keys.NumPad1;
             keys[(int)Action.CurrentDuplPairDeleteSecond] = Keys.NumPad2;
@@ -130,6 +155,8 @@ namespace AntiDupl.NET.WinForms
         
         public void CopyTo(ref HotKeyOptions options)
         {
+            Check();
+            options.Check();
             if (keys.Length != options.keys.Length)
                 options.keys = new Keys[(int)Action.Size];
             for (int i = 0; i < keys.Length; ++i)
@@ -138,6 +165,10 @@ namespace AntiDupl.NET.WinForms
 
         public bool Equals(HotKeyOptions options)
         {
+            Check();
+            if (options == null)
+                return false;
+            options.Check();
             if (keys.Length != options.keys.Length)
                 return false;
             for (int i = 0; i < keys.Length; ++i)
@@ -148,6 +179,7 @@ namespace AntiDupl.NET.WinForms
 
         public bool Valid(Action action)
         {
+            Check();
             KeyEventArgs key = new KeyEventArgs(keys[(int)action]);
             if(key.KeyData == Keys.None)
             {

--- a/src/AntiDupl.NET.WinForms/Options.cs
+++ b/src/AntiDupl.NET.WinForms/Options.cs
@@ -92,7 +92,14 @@ namespace AntiDupl.NET.WinForms
                     XmlSerializer xmlSerializer = new XmlSerializer(typeof(Options));
                     fileStream = new FileStream(Options.GetOptionsFileName(), FileMode.Open, FileAccess.Read);
                     Options options = (Options)xmlSerializer.Deserialize(fileStream);
-                    options.resultsOptions.Check();
+                    if (options.resultsOptions == null)
+                        options.resultsOptions = new ResultsOptions();
+                    else
+                        options.resultsOptions.Check();
+                    if (options.hotKeyOptions == null)
+                        options.hotKeyOptions = new HotKeyOptions();
+                    else
+                        options.hotKeyOptions.Check();
                     fileStream.Close();
                     return options;
                 }

--- a/src/AntiDupl.NET.WinForms/Properties/PublishProfiles/AntiDuplPublishSingleFile.pubxml
+++ b/src/AntiDupl.NET.WinForms/Properties/PublishProfiles/AntiDuplPublishSingleFile.pubxml
@@ -9,7 +9,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>..\..\out\Publish\AntiDupl.NET</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/src/AntiDupl/AntiDupl.vcxproj
+++ b/src/AntiDupl/AntiDupl.vcxproj
@@ -66,11 +66,11 @@
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdclatest</LanguageStandard_C>
       <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</MultiProcessorCompilation>
       <EnableParallelCodeGeneration Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</EnableParallelCodeGeneration>
-      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnableParallelCodeGeneration Condition="'$(Configuration)|$(Platform)'=='Publish|x64'">true</EnableParallelCodeGeneration>
-      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Publish|x64'">AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Publish|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnableParallelCodeGeneration Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</EnableParallelCodeGeneration>
-      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</BuildStlModules>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Publish|x64'">true</BuildStlModules>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</BuildStlModules>

--- a/src/AntiDupl/AntiDupl.vcxproj
+++ b/src/AntiDupl/AntiDupl.vcxproj
@@ -66,11 +66,11 @@
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdclatest</LanguageStandard_C>
       <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</MultiProcessorCompilation>
       <EnableParallelCodeGeneration Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</EnableParallelCodeGeneration>
-      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotSet</EnableEnhancedInstructionSet>
       <EnableParallelCodeGeneration Condition="'$(Configuration)|$(Platform)'=='Publish|x64'">true</EnableParallelCodeGeneration>
-      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Publish|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Publish|x64'">NotSet</EnableEnhancedInstructionSet>
       <EnableParallelCodeGeneration Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</EnableParallelCodeGeneration>
-      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotSet</EnableEnhancedInstructionSet>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</BuildStlModules>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Publish|x64'">true</BuildStlModules>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</BuildStlModules>


### PR DESCRIPTION
- Switch back EnableEnhancedInstructionSet from AdvancedVectorExtensions to NotSet, since no real benefit (Support CPUs without AVX (https://github.com/ermig1979/AntiDupl/issues/219), simd already use AVX if supported
- Fix Indexoutofrange ResultsListView cause due to new hotkey (https://github.com/ermig1979/AntiDupl/issues/227 and https://github.com/ermig1979/AntiDupl/issues/225)